### PR TITLE
Fixes for Shapely V2.0

### DIFF
--- a/shapestats/_amoments.py
+++ b/shapestats/_amoments.py
@@ -3,7 +3,7 @@ from libpysal.cg.shapes import Polygon, asShape
 
 
 def second_moa(chain):
-    """
+    r"""
     Using equation listed on en.wikipedia.org/Second_Moment_of_area, the second
     moment of area is actually the cross-moment of area between the X and Y
     dimensions:

--- a/shapestats/compactness.py
+++ b/shapestats/compactness.py
@@ -137,7 +137,12 @@ def moment_of_inertia(poly, dmetric=_dst.euclidean):
     and Hess (1963).
     """
     pointset = _get_pointset(poly)
-    dists = [dmetric(pt, poly.centroid)**2 for pt in pointset]
+    poly.centroid
+    try:
+        dists = [dmetric(pt, poly.centroid)**2 for pt in pointset]
+    except ValueError:
+        centroid_xy = np.array(poly.centroid.xy).T[0]
+        dists = [dmetric(pt, centroid_xy)**2 for pt in pointset]
     return poly.area / np.sqrt(2 * np.sum(dists))
 
 def flaherty_crumplin_radius(poly):

--- a/shapestats/compactness.py
+++ b/shapestats/compactness.py
@@ -20,8 +20,8 @@ __all__ = ['ipq', 'iaq', 'convex_hull', 'boundary_amplitude', 'reock',
 
 def ipq(poly):
     """
-    The Isoperimetric quotient, defined as the ratio of a poly's area to the 
-    area of the equi-perimeter circle. 
+    The Isoperimetric quotient, defined as the ratio of a poly's area to the
+    area of the equi-perimeter circle.
 
     Altman's PA_1 measure
 
@@ -30,7 +30,7 @@ def ipq(poly):
     let:
     p_d = perimeter of district
     a_d = area of district
-    
+
     a_c = area of the constructed circle
     r = radius of constructed circle
 
@@ -38,11 +38,11 @@ def ipq(poly):
     perimeter is:
     p_d = 2 \pi r
     p_d / (2 \pi) = r
-    
+
     meaning the area of the circle can be expressed as:
     a_c = \pi r^2
     a_c = \pi (p_d / (2\pi))^2
-    
+
     implying finally that the IPQ is:
 
     pp = (a_d) / (a_c) = (a_d) / ((p_d / (2*\pi))^2 * \pi) = (a_d) / (p_d**2 / (4\PI))
@@ -53,7 +53,7 @@ def convex_hull(poly):
     """
     ratio of the convex hull area to the area of the shape itself
 
-    Altman's A_3 measure, from Neimi et al 1991. 
+    Altman's A_3 measure, from Neimi et al 1991.
     """
     chull = to_shapely_geom(poly).convex_hull
     return poly.area / chull.area
@@ -71,25 +71,25 @@ def iaq(poly):
     The Isoareal quotient, defined as the ratio of a poly's perimeter to the
     perimeter of the equi-areal circle
 
-    Altman's PA_3 measure, and proportional to the PA_4 measure 
+    Altman's PA_3 measure, and proportional to the PA_4 measure
     """
     return (2 * _PI * np.sqrt(poly.area/_PI)) / poly.boundary.length
 
 def reock(poly):
     """
     The Reock compactness measure, defined by the ratio of areas between the
-    minimum bounding/containing circle of a shape and the shape itself. 
+    minimum bounding/containing circle of a shape and the shape itself.
 
     Measure A1 in Altman's thesis, cited for Frolov (1974), but earlier from Reock
     (1963)
     """
-    pointset = _get_pointset(poly) 
+    pointset = _get_pointset(poly)
     radius, (cx, cy) = _mbc(pointset)
     return poly.area / (_PI * radius ** 2)
 
 def contained_circle_aq(poly):
     """
-    The contained circle areal quotient is defined by the 
+    The contained circle areal quotient is defined by the
     ratio of the area of the
     largest contained circle and the shape itself.
     """
@@ -101,14 +101,14 @@ def nmi(poly):
     """
     Computes the Normalized Moment of Inertia from Li et al (2013), recognizing
     that it is the relationship between the area of a shape squared divided by
-    its second moment of area. 
+    its second moment of area.
     """
     return poly.area**2 / (2 * second_moa(poly) * _PI)
 
 def moa_ratio(poly):
     """
     Computes the ratio of the second moment of area (like Li et al (2013)) to
-    the moment of area of a circle with the same area. 
+    the moment of area of a circle with the same area.
     """
     r = poly.boundary.length / (2 * _PI)
     return (_PI * .5 * r**4) / second_moa(poly)
@@ -117,31 +117,31 @@ def moa_ratio(poly):
 
 def moment_of_inertia(poly, dmetric=_dst.euclidean):
     """
-    Computes the moment of inertia of the poly. 
+    Computes the moment of inertia of the poly.
 
     This treats each boundary point as a point-mass of 1.
 
-    Thus, for constant unit mass at each boundary point, 
+    Thus, for constant unit mass at each boundary point,
     the MoI of this pointcloud is
 
     \sum_i d_{i,c}^2
 
     where c is the centroid of the poly
-    
+
     Altman's OS_1 measure, cited in Boyce and Clark (1964), also used in Weaver
     and Hess (1963).
     """
-    pointset = _get_pointset(poly) 
+    pointset = _get_pointset(poly)
     dists = [dmetric(pt, poly.centroid)**2 for pt in pointset]
     return poly.area / np.sqrt(2 * np.sum(dists))
 
 def flaherty_crumplin_radius(poly):
     """
-    The Flaherty & Crumplin (1992) index, OS_3 in Altman's thesis. 
-    
+    The Flaherty & Crumplin (1992) index, OS_3 in Altman's thesis.
+
     The ratio of the radius of the equi-areal circle to the radius of the MBC
     """
-    pointset = _get_pointset(poly) 
+    pointset = _get_pointset(poly)
     r_eac = np.sqrt(poly.area/_PI)
     r_mbc, _ = _mbc(pointset)
     return r_eac / r_mbc
@@ -159,7 +159,7 @@ def taylor_reflexive(poly):
     N = 0
     for A in angles:
         ni =  (np.array(A) >= 0).sum()
-        N += ni 
+        N += ni
         R += len(A) - N
     return (N - R)/(N+R)
 
@@ -168,9 +168,9 @@ def taylor_reflexive(poly):
 def flaherty_crumplin_lw(poly):
     """
     The Flaherty & Crumplin (1992) length-width measure, stated as measure LW_7
-    in Altman's thesis. 
+    in Altman's thesis.
 
-    It is given as the ratio between the minimum and maximum shape diameter. 
+    It is given as the ratio between the minimum and maximum shape diameter.
     """
     _, minlen, _, maxlen = _u.unique_lw(poly)
     return minlen / maxlen
@@ -182,11 +182,11 @@ def eig_seitzinger(poly):
     L - W
 
     Where L is the maximal east-west extent and W is the maximal north-south
-    extent. 
+    extent.
 
     Defined as measure LW_5 in Altman's thesis
     """
-    ptset = _get_pointset(poly) 
+    ptset = _get_pointset(poly)
     xs, ys = [p[0] for p in ptset], [p[1] for p in ptset]
     l = np.max(xs) - np.min(xs)
     w = np.max(ys) - np.min(ys)

--- a/shapestats/compactness.py
+++ b/shapestats/compactness.py
@@ -24,7 +24,7 @@ __all__ = ['ipq', 'iaq', 'convex_hull', 'boundary_amplitude', 'reock',
 ### ---- Altman's PA/A measures ---- ##
 
 def ipq(poly):
-    """
+    r"""
     The Isoperimetric quotient, defined as the ratio of a poly's area to the
     area of the equi-perimeter circle.
 
@@ -121,7 +121,7 @@ def moa_ratio(poly):
 ## ---- Altman's OS Measures ---- ##
 
 def moment_of_inertia(poly, dmetric=_dst.euclidean):
-    """
+    r"""
     Computes the moment of inertia of the poly.
 
     This treats each boundary point as a point-mass of 1.

--- a/shapestats/compactness.py
+++ b/shapestats/compactness.py
@@ -1,7 +1,12 @@
 from __future__ import division
 from math import pi as _PI
 from libpysal.weights._contW_lists import _get_verts as _get_pointset
-from shapely.geometry import asShape as to_shapely_geom
+
+try:
+    from shapely.geometry import asShape as to_shapely_geom
+except ImportError:
+    from shapely.geometry import shape as to_shapely_geom
+
 from scipy.spatial import distance as _dst
 import numpy as np
 


### PR DESCRIPTION
The current library fails to import with shapely version `2.0.1`. Additionally, there are some other minor errors and warnings. This patch fixes them.

Most of the diff is whitespace cruft due to my editors. If that's a problem, we can resolve it by dropping commit 743dfe5.

The main fix is in compactness.py where I put a try except around `from shapely.geometry import asShape`, which has been deprecated. Using `shapely.geometry.shape` is the 2.0 way to do this.

There is another fix in `moment_of_inertia`, due to libpysal complaining about how the input must be a 1D vector. I fixed it with another heavy-handed try/except. 

Lastly, pytest warns about unescaped backslash characters due to the latex. This is fixed by prefixing the docstrings with "r", so "\" is treated like a literal backslash instead of an escape character.

Not sure if this library is maintained or not, but I can help with the release process if you want to maintain it.